### PR TITLE
add gha for codeberg mirroring; add CITATION.cff; fix #147; fix #145; fix #149; fix #150

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,4 @@
 ˆvignettes/sample_size.html$
 ^CODE_OF_CONDUCT\.md$
 ^vignettes/\.quarto$
+^CITATION\.cff$

--- a/.github/workflows/mirror-codeberg.yaml
+++ b/.github/workflows/mirror-codeberg.yaml
@@ -1,0 +1,19 @@
+name: Mirror to other git server
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: yesolutions/mirror-action@master
+        with:
+          REMOTE: https://codeberg.org/nutriverse/mwana
+          GIT_USERNAME: ${{ secrets.CODEBERG_USERNAME }}
+          GIT_PASSWORD: ${{ secrets.CODEBERG_TOKEN }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,330 @@
+# --------------------------------------------
+# CITATION file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# --------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "mwana" in publications use:'
+type: software
+license: GPL-3.0-or-later
+title: 'mwana: An Efficient Workflow for Plausibility Checks and Prevalence Analysis
+  of Wasting in R'
+version: 0.2.2.9000
+doi: 10.5281/zenodo.14176624
+abstract: A simple and streamlined workflow for plausibility checks and prevalence
+  analysis of wasting based on the Standardized Monitoring and Assessment of Relief
+  and Transition (SMART) Methodology <https://smartmethodology.org/>, with application
+  in R.
+authors:
+- family-names: Zaba
+  given-names: Tomás
+  email: tomas.zaba@outlook.com
+  orcid: https://orcid.org/0000-0002-7079-3574
+- family-names: Guevarra
+  given-names: Ernest
+  orcid: https://orcid.org/0000-0002-4887-4415
+preferred-citation:
+  type: manual
+  title: 'mwana: An Efficient Workflow for Plausibility Checks and Prevalence Analysis
+    of Wasting in R'
+  authors:
+  - name: Tomás Zaba
+  - name: Ernest Guevarra
+  year: '2024'
+  notes: R package version 0.2.1
+  url: https://nutriverse.io/mwana/
+  doi: 10.5281/zenodo.14176624
+repository-code: https://github.com/nutriverse/mwana
+url: https://nutriverse.io/mwana
+contact:
+- family-names: Zaba
+  given-names: Tomás
+  email: tomas.zaba@outlook.com
+  orcid: https://orcid.org/0000-0002-7079-3574
+keywords:
+- acute-malnutrition
+- anthropometry
+- muac
+- nutrition
+- smart
+- survey
+- wasting
+references:
+- type: software
+  title: 'R: A Language and Environment for Statistical Computing'
+  notes: Depends
+  url: https://www.R-project.org/
+  authors:
+  - name: R Core Team
+  institution:
+    name: R Foundation for Statistical Computing
+    address: Vienna, Austria
+  year: '2025'
+  version: '>= 4.1'
+- type: software
+  title: dplyr
+  abstract: 'dplyr: A Grammar of Data Manipulation'
+  notes: Imports
+  url: https://dplyr.tidyverse.org
+  repository: https://CRAN.R-project.org/package=dplyr
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+    orcid: https://orcid.org/0000-0003-4757-117X
+  - family-names: François
+    given-names: Romain
+    orcid: https://orcid.org/0000-0002-2444-4226
+  - family-names: Henry
+    given-names: Lionel
+  - family-names: Müller
+    given-names: Kirill
+    orcid: https://orcid.org/0000-0002-1416-3412
+  - family-names: Vaughan
+    given-names: Davis
+    email: davis@posit.co
+    orcid: https://orcid.org/0000-0003-4777-038X
+  year: '2025'
+  doi: 10.32614/CRAN.package.dplyr
+  version: '>= 1.1.4'
+- type: software
+  title: lubridate
+  abstract: 'lubridate: Make Dealing with Dates a Little Easier'
+  notes: Imports
+  url: https://lubridate.tidyverse.org
+  repository: https://CRAN.R-project.org/package=lubridate
+  authors:
+  - family-names: Spinu
+    given-names: Vitalie
+    email: spinuvit@gmail.com
+  - family-names: Grolemund
+    given-names: Garrett
+  - family-names: Wickham
+    given-names: Hadley
+  year: '2025'
+  doi: 10.32614/CRAN.package.lubridate
+- type: software
+  title: nipnTK
+  abstract: 'nipnTK: National Information Platforms for Nutrition Anthropometric Data
+    Toolkit'
+  notes: Imports
+  url: https://nutriverse.io/nipnTK/
+  repository: https://CRAN.R-project.org/package=nipnTK
+  authors:
+  - family-names: Myatt
+    given-names: Mark
+    email: mark@brixtonhealth.com
+    orcid: https://orcid.org/0000-0003-1119-1474
+  - family-names: Guevarra
+    given-names: Ernest
+    email: ernest@guevarra.io
+    orcid: https://orcid.org/0000-0002-4887-4415
+  year: '2025'
+  doi: 10.32614/CRAN.package.nipnTK
+- type: software
+  title: rlang
+  abstract: 'rlang: Functions for Base Types and Core R and ''Tidyverse'' Features'
+  notes: Imports
+  url: https://rlang.r-lib.org
+  repository: https://CRAN.R-project.org/package=rlang
+  authors:
+  - family-names: Henry
+    given-names: Lionel
+    email: lionel@posit.co
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2025'
+  doi: 10.32614/CRAN.package.rlang
+- type: software
+  title: scales
+  abstract: 'scales: Scale Functions for Visualization'
+  notes: Imports
+  url: https://scales.r-lib.org
+  repository: https://CRAN.R-project.org/package=scales
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  - family-names: Pedersen
+    given-names: Thomas Lin
+    email: thomas.pedersen@posit.co
+    orcid: https://orcid.org/0000-0002-5147-4711
+  - family-names: Seidel
+    given-names: Dana
+  year: '2025'
+  doi: 10.32614/CRAN.package.scales
+- type: software
+  title: srvyr
+  abstract: 'srvyr: ''dplyr''-Like Syntax for Summary Statistics of Survey Data'
+  notes: Imports
+  url: http://gdfe.co/srvyr/
+  repository: https://CRAN.R-project.org/package=srvyr
+  authors:
+  - family-names: Freedman Ellis
+    given-names: Greg
+    email: greg.freedman@gmail.com
+  - family-names: Schneider
+    given-names: Ben
+  year: '2025'
+  doi: 10.32614/CRAN.package.srvyr
+- type: software
+  title: stats
+  abstract: 'R: A Language and Environment for Statistical Computing'
+  notes: Imports
+  authors:
+  - name: R Core Team
+  institution:
+    name: R Foundation for Statistical Computing
+    address: Vienna, Austria
+  year: '2025'
+- type: software
+  title: zscorer
+  abstract: 'zscorer: Child Anthropometry z-Score Calculator'
+  notes: Imports
+  url: https://github.com/nutriverse/zscorer
+  repository: https://CRAN.R-project.org/package=zscorer
+  authors:
+  - family-names: Myatt
+    given-names: Mark
+    email: mark@brixtonhealth.com
+    orcid: https://orcid.org/0000-0003-1119-1474
+  - family-names: Guevarra
+    given-names: Ernest
+    email: ernestgmd@gmail.com
+    orcid: https://orcid.org/0000-0002-4887-4415
+  year: '2025'
+  doi: 10.32614/CRAN.package.zscorer
+- type: software
+  title: tibble
+  abstract: 'tibble: Simple Data Frames'
+  notes: Imports
+  url: https://tibble.tidyverse.org/
+  repository: https://CRAN.R-project.org/package=tibble
+  authors:
+  - family-names: Müller
+    given-names: Kirill
+    email: kirill@cynkra.com
+    orcid: https://orcid.org/0000-0002-1416-3412
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@rstudio.com
+  year: '2025'
+  doi: 10.32614/CRAN.package.tibble
+- type: software
+  title: methods
+  abstract: 'R: A Language and Environment for Statistical Computing'
+  notes: Imports
+  authors:
+  - name: R Core Team
+  institution:
+    name: R Foundation for Statistical Computing
+    address: Vienna, Austria
+  year: '2025'
+- type: software
+  title: knitr
+  abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
+  notes: Suggests
+  url: https://yihui.org/knitr/
+  repository: https://CRAN.R-project.org/package=knitr
+  authors:
+  - family-names: Xie
+    given-names: Yihui
+    email: xie@yihui.name
+    orcid: https://orcid.org/0000-0003-0645-5666
+  year: '2025'
+  doi: 10.32614/CRAN.package.knitr
+- type: software
+  title: rmarkdown
+  abstract: 'rmarkdown: Dynamic Documents for R'
+  notes: Suggests
+  url: https://pkgs.rstudio.com/rmarkdown/
+  repository: https://CRAN.R-project.org/package=rmarkdown
+  authors:
+  - family-names: Allaire
+    given-names: JJ
+    email: jj@posit.co
+  - family-names: Xie
+    given-names: Yihui
+    email: xie@yihui.name
+    orcid: https://orcid.org/0000-0003-0645-5666
+  - family-names: Dervieux
+    given-names: Christophe
+    email: cderv@posit.co
+    orcid: https://orcid.org/0000-0003-4474-2498
+  - family-names: McPherson
+    given-names: Jonathan
+    email: jonathan@posit.co
+  - family-names: Luraschi
+    given-names: Javier
+  - family-names: Ushey
+    given-names: Kevin
+    email: kevin@posit.co
+  - family-names: Atkins
+    given-names: Aron
+    email: aron@posit.co
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  - family-names: Cheng
+    given-names: Joe
+    email: joe@posit.co
+  - family-names: Chang
+    given-names: Winston
+    email: winston@posit.co
+  - family-names: Iannone
+    given-names: Richard
+    email: rich@posit.co
+    orcid: https://orcid.org/0000-0003-3925-190X
+  year: '2025'
+  doi: 10.32614/CRAN.package.rmarkdown
+- type: software
+  title: quarto
+  abstract: 'quarto: R Interface to ''Quarto'' Markdown Publishing System'
+  notes: Suggests
+  url: https://quarto-dev.github.io/quarto-r/
+  repository: https://CRAN.R-project.org/package=quarto
+  authors:
+  - family-names: Allaire
+    given-names: JJ
+    email: jj@posit.co
+    orcid: https://orcid.org/0000-0003-0174-9868
+  - family-names: Dervieux
+    given-names: Christophe
+    email: cderv@posit.co
+    orcid: https://orcid.org/0000-0003-4474-2498
+  year: '2025'
+  doi: 10.32614/CRAN.package.quarto
+- type: software
+  title: spelling
+  abstract: 'spelling: Tools for Spell Checking in R'
+  notes: Suggests
+  url: https://ropensci.r-universe.dev/spelling
+  repository: https://CRAN.R-project.org/package=spelling
+  authors:
+  - family-names: Ooms
+    given-names: Jeroen
+    email: jeroenooms@gmail.com
+    orcid: https://orcid.org/0000-0002-4035-0289
+  - family-names: Hester
+    given-names: Jim
+    email: james.hester@rstudio.com
+  year: '2025'
+  identifiers:
+  - type: url
+    value: https://docs.ropensci.org/spelling/
+  doi: 10.32614/CRAN.package.spelling
+- type: software
+  title: testthat
+  abstract: 'testthat: Unit Testing for R'
+  notes: Suggests
+  url: https://testthat.r-lib.org
+  repository: https://CRAN.R-project.org/package=testthat
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2025'
+  doi: 10.32614/CRAN.package.testthat
+  version: '>= 3.0.0'
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: mwana
 Title: An Efficient Workflow for Plausibility Checks and Prevalence Analysis of
     Wasting in R
-Version: 0.2.1.9000
+Version: 0.2.2.9000
 Authors@R: c(
     person("Tomás", "Zaba", , "tomas.zaba@outlook.com", 
            role = c("aut", "cre", "cph"),


### PR DESCRIPTION
fix #145; fix #147; fix #149; fix #150

@tomaszaba, this pull request sets up the Codeberg mirroring of this repository. We do this via a GitHub Action that will mirror every new commit to this repo that is merged to main.

You can test this by approving this PR and then merging to main. This will trigger the action and then all the new commits to main will be mirrored here - https://codeberg.org/nutriverse/mwana.

In this approach, we can continue working using GitHub (at the moment, this is still the better tool and we get a lot more publicity to a general userbase which is important for us so that more people will use our packages). And since no immediate threat is in the horizon with regard to github removing our repositories for whatever reason and while GitHub is still relatively OK and what most of the developers we know are still using, then our workfow shouldn't change. And with this automation, all our work is always backed-up and mirrored in Codeberg which will make it tremendously easy to transition there if we need/want to.

I have moved all my personal repositories now to Codeberg and will use that for those projects instead of GitHub. For our organisational work, I think that decision is harder to make and GitHub is still our most viable option.